### PR TITLE
Fix alignment on content edition form

### DIFF
--- a/templates/forms/modules_theme.html.twig
+++ b/templates/forms/modules_theme.html.twig
@@ -115,7 +115,7 @@
                 {# form_name #}
                 <button type="button" class="btn-close" data-cms-module-form-close="" aria-label="Close"></button>
             </div>
-            <div class="container">
+            <div class="container text-start">
                 {% if form.vars.deprecated %}
                     <div class="alert alert-warning mt-3" role="alert">{{ form.vars.deprecated }}</div>
                 {% endif %}


### PR DESCRIPTION
When editing content, it could be a module with some class input and class sync enabled, if text-center class is set it affects to the edition form.
