### PR TITLE
Fix version id in _version_list_table.html.twig

### DIFF
--- a/templates/admin/content/_version_list_table.html.twig
+++ b/templates/admin/content/_version_list_table.html.twig
@@ -24,9 +24,9 @@
             <td>{{ ('admin_'~content_type~'.versions.origin.'~(version.origin|default('null')))|trans }} {{ version.originDescription ? '('~version.originDescription~')' : '' }}</td>
             <td>
                 {% if version.note %}
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':version}) }}"><i class="bi bi-tag"></i> {{ version.note }}</a>
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':version.id}) }}"><i class="bi bi-tag"></i> {{ version.note }}</a>
                 {% else %}
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':version}) }}" class="text-muted"><i class="bi bi-tag"></i> {{ ('admin_'~content_type~'.versions.actions.add_note.link')|trans }}</a>
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':version.id}) }}" class="text-muted"><i class="bi bi-tag"></i> {{ ('admin_'~content_type~'.versions.actions.add_note.link')|trans }}</a>
                 {% endif %}
             </td>
             <td>
@@ -41,12 +41,12 @@
                 {% if not content_config.admin.version_lock.is_granted or is_granted(content_config.admin.version_lock.is_granted, version) %}
                     {% if version.keep %}
                         <a class=""
-                           href="{{ url('sfs_cms_admin_content_'~content_type~'_unkeep_version', {'content':entity, 'version':version, 'back': backSection}) }}"
+                           href="{{ url('sfs_cms_admin_content_'~content_type~'_unkeep_version', {'content':entity, 'version':version.id, 'back': backSection}) }}"
                            title="{{ ('admin_'~content_type~'.versions.actions.keep.link')|trans }}"><i
                                     class="bi bi-pin-angle-fill"></i></a>
                     {% else %}
                         <a class=""
-                           href="{{ url('sfs_cms_admin_content_'~content_type~'_keep_version', {'content':entity, 'version':version, 'back': backSection}) }}"
+                           href="{{ url('sfs_cms_admin_content_'~content_type~'_keep_version', {'content':entity, 'version':version.id, 'back': backSection}) }}"
                            title="{{ ('admin_'~content_type~'.versions.actions.nokeep.link')|trans }}"><i
                                     class="bi bi-pin-angle"></i></a>
                     {% endif %}
@@ -62,7 +62,7 @@
             </td>
             <td>
                 {% if not content_config.admin.version_info.is_granted or is_granted(content_config.admin.version_info.is_granted, version) %}
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':version}) }}"
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':version.id}) }}"
                        class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.versions.actions.info.link')|trans }} <span
                                 class="bi bi-info"></span></a>
                 {% endif %}
@@ -74,20 +74,20 @@
                 {% endif %}
 
                 {% if not content_config.admin.preview.is_granted or is_granted(content_config.admin.preview.is_granted, version) %}
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_preview', {'content':entity, 'version':version}) }}"
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_preview', {'content':entity, 'version':version.id}) }}"
                        class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.versions.actions.preview.link')|trans }}
                         <span class="bi bi-eye"></span></a>
                 {% endif %}
 
                 {% if not content_config.admin.export_version.is_granted or is_granted(content_config.admin.export_version.is_granted, version) %}
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_export_version', {'content':entity, 'version':version}) }}"
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_export_version', {'content':entity, 'version':version.id}) }}"
                        class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.versions.actions.export.link')|trans }}
                         <span class="bi bi-box-arrow-down"></span></a>
                 {% endif %}
 
                 {% if not content_config.admin.publish_version.is_granted or is_granted(content_config.admin.publish_version.is_granted, version) %}
                     {% if not version.published %}
-                        <a href="{{ url('sfs_cms_admin_content_'~content_type~'_publish_version', {'content':entity, 'version':version, 'back': backSection}) }}"
+                        <a href="{{ url('sfs_cms_admin_content_'~content_type~'_publish_version', {'content':entity, 'version':version.id, 'back': backSection}) }}"
                            data-confirm-modal="{{ ('admin_'~content_type~'.version_publish.confirm_message_raw')|trans|base64_encode }}"
                            data-confirm-modal-title="{{ ('admin_'~content_type~'.version_publish.confirm_message_title')|trans }}"
                            class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.versions.actions.publish.link')|trans }}


### PR DESCRIPTION
To prevent render as "preview?version%5B__isInitialized__%5D=1" when version entity is not loaded