### PR TITLE
Improve hreflang management for sites

### DIFF
--- a/src/Config/Model/Site.php
+++ b/src/Config/Model/Site.php
@@ -128,6 +128,7 @@ class Site implements ConfigurationInterface
                             ->booleanNode('alternates')->setDeprecated('softspring/cms-bundle', '5.1', 'Use alternates_locales and alternates_sites')->defaultTrue()->end()
                             ->booleanNode('alternates_locales')->defaultTrue()->end()
                             ->booleanNode('alternates_sites')->defaultTrue()->end()
+                            ->booleanNode('alternates_include_hreflang')->defaultTrue()->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Helper/RoutingHelper.php
+++ b/src/Helper/RoutingHelper.php
@@ -16,16 +16,16 @@ class RoutingHelper
     /**
      * Generates the alternate URLs for a route path in all sites and languages.
      */
-    public function generateRoutePathAlternates(RoutePathInterface $path, SiteInterface $site, bool $localeAlternates = true, bool $siteAlternates = true): array
+    public function generateRoutePathAlternates(RoutePathInterface $path, SiteInterface $site, bool $localeAlternates = true, bool $siteAlternates = true, bool $addHrefLang = true): array
     {
-        $alternates = $localeAlternates ? $this->generateRoutePathAlternatesForSite($site, $path) : [];
+        $alternates = $localeAlternates ? $this->generateRoutePathAlternatesForSite($site, $path, $addHrefLang) : [];
 
         if (!$siteAlternates) {
             return $alternates;
         }
 
         foreach ($path->getRoute()->getSites()->filter(fn ($as) => $as !== $site) as $alternateSite) {
-            $alternates = array_merge($alternates, $this->generateRoutePathAlternatesForSite($alternateSite, $path));
+            $alternates = array_merge($alternates, $this->generateRoutePathAlternatesForSite($alternateSite, $path, $addHrefLang));
         }
 
         return $alternates;
@@ -34,7 +34,7 @@ class RoutingHelper
     /**
      * Generates the alternate URLs for a route path in a site.
      */
-    public function generateRoutePathAlternatesForSite(SiteInterface $site, RoutePathInterface $path): array
+    public function generateRoutePathAlternatesForSite(SiteInterface $site, RoutePathInterface $path, bool $addHrefLang = true): array
     {
         $alternates = [];
 
@@ -45,9 +45,8 @@ class RoutingHelper
 
             $alternates[] = [
                 '@rel' => 'alternate',
-                '@hreflang' => $alternatePath->getLocale(),
                 '@href' => $this->urlGenerator->getUrlFixed($alternatePath, $site),
-            ];
+            ] + ($addHrefLang ? ['@hreflang' => $site->getGeoHrefLangForLocale($alternatePath->getLocale())] : []);
         }
 
         return $alternates;

--- a/src/Model/Site.php
+++ b/src/Model/Site.php
@@ -56,4 +56,11 @@ class Site implements SiteInterface
         // return first host as default
         return $this->getConfig()['hosts'][0]['scheme'] ?? null;
     }
+
+    public function getGeoHrefLangForLocale(string $locale): string
+    {
+        $extraConfig = $this->getConfig()['extra'] ?? [];
+
+        return $extraConfig['hreflang_mapping'][$locale] ?? $locale;
+    }
 }

--- a/src/Model/SiteInterface.php
+++ b/src/Model/SiteInterface.php
@@ -17,4 +17,6 @@ interface SiteInterface
     public function getCanonicalHost(): ?string;
 
     public function getCanonicalScheme(): ?string;
+
+    public function getGeoHrefLangForLocale(string $locale): string;
 }

--- a/src/Sitemap/SitemapFactory.php
+++ b/src/Sitemap/SitemapFactory.php
@@ -45,6 +45,8 @@ class SitemapFactory
         /* @deprecated will only use alternates_sites */
         $siteAlternates = $sitemapConfig['alternates'] || $sitemapConfig['alternates_sites'];
 
+        $alternatesIncludeHreflang = $sitemapConfig['alternates_include_hreflang'] ?? true;
+
         foreach ($content->getRoutes() as $route) {
             foreach ($route->getPaths() as $path) {
                 if (!in_array($path->getLocale(), $site->getConfig()['locales'])) {
@@ -56,7 +58,7 @@ class SitemapFactory
                     'lastmod' => $content->getPublishedVersion()?->getCreatedAt()->format('Y-m-d'),
                     'changefreq' => $this->getChangeFreq($content, $sitemapConfig),
                     'priority' => $this->getPriority($content, $sitemapConfig),
-                    'xhtml:link' => $this->routingHelper->generateRoutePathAlternates($path, $site, $localeAlternates, $siteAlternates),
+                    'xhtml:link' => $this->routingHelper->generateRoutePathAlternates($path, $site, $localeAlternates, $siteAlternates, $alternatesIncludeHreflang),
                 ], fn ($v) => !empty($v));
             }
         }


### PR DESCRIPTION
Sites can disable hreflang for alternates in sitemaps:

```yaml
site:
    sitemaps:
        default:
            alternates_include_hreflang: false
```

This also allows to map hreflangs for sites:

```yaml
site:
    extra:
        hreflang_mapping:
            es: es-ES
            pt: pt-PT
```

This will be used in head alternates and sitemap alternates.