### PR TITLE
Fix grid module content modules filtering by breakline

### DIFF
--- a/cms/modules/grid/render.html.twig
+++ b/cms/modules/grid/render.html.twig
@@ -1,7 +1,7 @@
 {% import '@SfsCms/macros/modules_render.html.twig' as module %}
 
 <div {{ module.id(id) }} {{ module.class(class, 'grid-module row') }} {{ module.bg_color(bg_color) }}>
-    {% for content in contents|filter(content => content != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::LOCALE_HIDDEN_MODULE') and content != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::SITE_HIDDEN_MODULE')) %}
+    {% for content in contents|filter(content => (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::LOCALE_HIDDEN_MODULE') and (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::SITE_HIDDEN_MODULE')) %}
         <div class="{{ node_row_class|default(node_row_class_custom|default('col mb-4')) }}">{{ content|raw }}</div>
     {% endfor %}
 </div>

--- a/cms/modules/grid/render.html.twig
+++ b/cms/modules/grid/render.html.twig
@@ -1,7 +1,7 @@
 {% import '@SfsCms/macros/modules_render.html.twig' as module %}
 
 <div {{ module.id(id) }} {{ module.class(class, 'grid-module row') }} {{ module.bg_color(bg_color) }}>
-    {% for content in contents|filter(content => (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::LOCALE_HIDDEN_MODULE') and (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::SITE_HIDDEN_MODULE')) %}
+    {% for content in contents|filter(content => (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::LOCALE_HIDDEN_MODULE') and (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::SITE_HIDDEN_MODULE') and (content|trim) != constant('Softspring\\CmsBundle\\Render\\ModuleRenderer::DISABLED_HIDDEN_MODULE')) %}
         <div class="{{ node_row_class|default(node_row_class_custom|default('col mb-4')) }}">{{ content|raw }}</div>
     {% endfor %}
 </div>


### PR DESCRIPTION
When a module is hidden by locale or site it renders a comment as content: "<!-- LOCALE_HIDDEN_MODULE -->" or "<!-- SITE_HIDDEN_MODULE -->". 

But there is a line break (\n) at the end of them.