### PR TITLE
Fix configurations for the admin

### DIFF
--- a/translations/sfs_cms_admin.en.yaml
+++ b/translations/sfs_cms_admin.en.yaml
@@ -175,8 +175,8 @@ admin_routes:
     types:
         0.name: "Unkwown"
         1.name: "Content"
-        2.name: "Redirect %redirectType% to route"
-        3.name: "Redirect %redirectType% to URL"
+        2.name: "Redirect to route"
+        3.name: "Redirect to URL"
         4.name: "Parent route"
 
 admin_menus:

--- a/translations/sfs_cms_admin.es.yaml
+++ b/translations/sfs_cms_admin.es.yaml
@@ -175,8 +175,8 @@ admin_routes:
     types:
         0.name: "Indefinido"
         1.name: "Contenido"
-        2.name: "Redirección %redirectType% a ruta"
-        3.name: "Redirección %redirectType% a URL"
+        2.name: "Redirección a ruta"
+        3.name: "Redirección a URL"
         4.name: "Ruta padre"
 
 admin_menus:


### PR DESCRIPTION
Right now, this shows like this `Redirect %redirectType% to route` or `Redirect %redirectType% to URL`. Maybe we don't strictly need to show the type (temporary/permanent) and this was the easiest solution, so I removed it, but feel free to fix this in a different way and close this pr

I'd also change the column currently named  `Route` to  ID because it doesn't actually contain the route but the ID. Nevertheless, maybe there could also be a column that lists the "paths". Not sure if it's worth it, because we can simply click "view" to see them